### PR TITLE
Filter latest historial record

### DIFF
--- a/cmms_fabrica/modulos/app_reportes.py
+++ b/cmms_fabrica/modulos/app_reportes.py
@@ -61,6 +61,19 @@ def generar_excel(df, nombre):
     output.seek(0)
     return output
 
+
+def filtrar_ultimo_por_activo(df: pd.DataFrame, key: str = "id_activo_tecnico") -> pd.DataFrame:
+    """Devuelve el registro m\u00e1s reciente por activo t\u00e9cnico.
+
+    Esto asegura la trazabilidad conforme a ISO 9001:2015 al conservar solo la
+    \u00faltima observaci\u00f3n registrada por activo.
+    """
+    if key not in df.columns or "fecha_evento" not in df.columns:
+        return df
+    ordenado = df.sort_values("fecha_evento", ascending=False)
+    idx = ordenado.groupby(key)["fecha_evento"].idxmax()
+    return ordenado.loc[idx].reset_index(drop=True)
+
 def app():
     st.title("📄 Reportes Técnicos del CMMS")
 
@@ -110,6 +123,8 @@ def app():
         df["usuario_registro"] = "desconocido"
     if "observaciones" not in df.columns:
         df["observaciones"] = "-"
+
+    df = filtrar_ultimo_por_activo(df)
 
     columnas = ["fecha_evento", "tipo_evento", "id_activo_tecnico", "descripcion", "observaciones", "usuario_registro"]
 

--- a/tests/test_reportes.py
+++ b/tests/test_reportes.py
@@ -1,5 +1,9 @@
 import pandas as pd
-from cmms_fabrica.modulos.app_reportes import generar_pdf, generar_excel
+from cmms_fabrica.modulos.app_reportes import (
+    generar_pdf,
+    generar_excel,
+    filtrar_ultimo_por_activo,
+)
 
 
 def test_generar_reportes_con_observaciones(tmp_path):
@@ -17,3 +21,18 @@ def test_generar_reportes_con_observaciones(tmp_path):
     assert pdf_path.endswith(".pdf")
     excel_buffer = generar_excel(df[columnas], "tmp")
     assert excel_buffer.getbuffer().nbytes > 0
+
+
+def test_filtrar_ultimo_por_activo():
+    df = pd.DataFrame(
+        {
+            "fecha_evento": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-05")],
+            "tipo_evento": ["test", "test"],
+            "id_activo_tecnico": ["A1", "A1"],
+            "descripcion": ["primero", "segundo"],
+            "usuario_registro": ["u", "u"],
+        }
+    )
+    filtrado = filtrar_ultimo_por_activo(df)
+    assert len(filtrado) == 1
+    assert filtrado.iloc[0]["descripcion"] == "segundo"


### PR DESCRIPTION
## Summary
- keep only the latest registro per asset in reportes
- provide helper `filtrar_ultimo_por_activo`
- use filtered data to generate previews and report files
- test helper to ensure most recent record is selected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo' and 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856d46e73e0832bbdd970bbf3203546