### PR TITLE
Documentar uso de fecha_evento

### DIFF
--- a/cmms_fabrica/modulos/app_reportes.py
+++ b/cmms_fabrica/modulos/app_reportes.py
@@ -83,6 +83,8 @@ def app():
         st.error("⚠️ La fecha 'desde' no puede ser posterior a la fecha 'hasta'.")
         return
 
+    # Filtrado por fecha_evento según la definición en docs/estructura_sistema.md
+    # (sección "Timestamps")
     query = {
         "fecha_evento": {
             "$gte": datetime.combine(fecha_desde, datetime.min.time()),

--- a/docs/estructura_sistema.md
+++ b/docs/estructura_sistema.md
@@ -1,3 +1,7 @@
 # Estructura del Sistema
 
 Los módulos se agrupan en `crud/` y `modulos/` para facilitar el mantenimiento y la escalabilidad del CMMS.
+
+## Timestamps
+La coleccion `historial` almacena los eventos con el campo `fecha_evento`. Este valor se genera en `crud/generador_historial.py` y representa la fecha y hora efectivas de cada actualizacion.
+Otros registros guardan `fecha_registro` para indicar cuando se creo la entrada, pero el orden cronologico y los filtros de reportes siempre se basan en `fecha_evento`.


### PR DESCRIPTION
## Summary
- documentar en la estructura del sistema que `fecha_evento` es la fecha de referencia
- agregar comentario en el filtro de fechas de `app_reportes.py` enlazando a la documentacion

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6856d4755048832ba11510ce02b89c79