### PR TITLE
Fix report grouping by event origin

### DIFF
--- a/cmms_fabrica/modulos/app_reportes.py
+++ b/cmms_fabrica/modulos/app_reportes.py
@@ -62,11 +62,12 @@ def generar_excel(df, nombre):
     return output
 
 
-def filtrar_ultimo_por_activo(df: pd.DataFrame, key: str = "id_activo_tecnico") -> pd.DataFrame:
-    """Devuelve el registro m\u00e1s reciente por activo t\u00e9cnico.
+def filtrar_ultimo_por_activo(df: pd.DataFrame, key: str = "id_origen") -> pd.DataFrame:
+    """Devuelve el registro m\u00e1s reciente agrupado por ``key``.
 
-    Esto asegura la trazabilidad conforme a ISO 9001:2015 al conservar solo la
-    \u00faltima observaci\u00f3n registrada por activo.
+    Por defecto se utiliza ``id_origen`` para mostrar solo la \u00faltima
+    actualizaci\u00f3n de cada evento, mejorando la trazabilidad seg\u00fan las
+    directrices de ISO 9001:2015.
     """
     if key not in df.columns or "fecha_evento" not in df.columns:
         return df

--- a/docs/estructura_sistema.md
+++ b/docs/estructura_sistema.md
@@ -5,3 +5,5 @@ Los módulos se agrupan en `crud/` y `modulos/` para facilitar el mantenimiento 
 ## Timestamps
 La coleccion `historial` almacena los eventos con el campo `fecha_evento`. Este valor se genera en `crud/generador_historial.py` y representa la fecha y hora efectivas de cada actualizacion.
 Otros registros guardan `fecha_registro` para indicar cuando se creo la entrada, pero el orden cronologico y los filtros de reportes siempre se basan en `fecha_evento`.
+
+Para los reportes se conserva solo la última actualización registrada por `id_origen`, mejorando la trazabilidad de cada evento individual.

--- a/tests/test_reportes.py
+++ b/tests/test_reportes.py
@@ -23,12 +23,13 @@ def test_generar_reportes_con_observaciones(tmp_path):
     assert excel_buffer.getbuffer().nbytes > 0
 
 
-def test_filtrar_ultimo_por_activo():
+def test_filtrar_ultimo_por_evento():
     df = pd.DataFrame(
         {
             "fecha_evento": [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-05")],
             "tipo_evento": ["test", "test"],
             "id_activo_tecnico": ["A1", "A1"],
+            "id_origen": ["EV1", "EV1"],
             "descripcion": ["primero", "segundo"],
             "usuario_registro": ["u", "u"],
         }


### PR DESCRIPTION
## Summary
- show latest historial record per `id_origen`
- document grouping choice in system docs
- adapt report tests to new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_6856db531dc8832ba1e4a9ce6f61455e