### PR TITLE
Fix duplicate Streamlit form key

### DIFF
--- a/cmms_fabrica/crud/crud_inventario.py
+++ b/cmms_fabrica/crud/crud_inventario.py
@@ -15,9 +15,17 @@ from crud.generador_historial import registrar_evento_historial
 coleccion = db["inventario"]
 
 
-def form_item(defaults=None):
-    """Formulario para cargar o editar un ítem del inventario."""
-    with st.form("form_inventario"):
+def form_item(defaults=None, key: str = "form_inventario"):
+    """Formulario para cargar o editar un ítem del inventario.
+
+    Parameters
+    ----------
+    defaults : dict, optional
+        Valores por defecto para editar un ítem existente.
+    key : str, default "form_inventario"
+        Identificador único del formulario en la interfaz.
+    """
+    with st.form(key):
         col1, col2 = st.columns(2)
         with col1:
             id_item = st.text_input("ID del ítem", value=defaults.get("id_item") if defaults else "")
@@ -115,7 +123,7 @@ def app_inventario(usuario: str) -> None:
 
     with pestañas[1]:
         st.markdown("### ➕ Agregar nuevo ítem")
-        data = form_item()
+        data = form_item(key="form_nuevo_item")
         if data:
             if coleccion.find_one({"id_item": data["id_item"]}):
                 st.error("⚠️ Ya existe un ítem con ese ID.")


### PR DESCRIPTION
## Summary
- add parameter to `form_item` for unique Streamlit form keys
- use `form_nuevo_item` for the new item form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_6857138a4ac0832b850ff7f1861d7ce6