### PR TITLE
Use shared historial registrar

### DIFF
--- a/cmms_fabrica/crud/crud_activos_tecnicos.py
+++ b/cmms_fabrica/crud/crud_activos_tecnicos.py
@@ -13,19 +13,9 @@ Registra automáticamente los eventos en la colección `historial` para trazabil
 import streamlit as st
 from datetime import datetime
 from modulos.conexion_mongo import db
+from crud.generador_historial import registrar_evento_historial
 
 coleccion = db["activos_tecnicos"]
-historial = db["historial"]
-
-def registrar_evento_historial(evento):
-    historial.insert_one({
-        "tipo_evento": evento["tipo_evento"],
-        "id_activo_tecnico": evento.get("id_activo_tecnico"),
-        "descripcion": evento.get("descripcion", ""),
-        "usuario": evento.get("usuario"),
-        "fecha_evento": datetime.now(),
-        "modulo": "activos_tecnicos"
-    })
 
 def app():
     st.title("🔧 Gestión de Activos Técnicos")


### PR DESCRIPTION
## Summary
- refactor `crud_activos_tecnicos` to use shared `registrar_evento_historial`

## Testing
- `MONGO_URI='mongodb://localhost:27017' PYTHONPATH=$PWD/cmms_fabrica python -m pytest -q` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_685f31ea8fa8832baaf2c000a4eae4d9