### PR TITLE
Remove unused imports

### DIFF
--- a/cmms_fabrica/crud/crud_calibraciones_instrumentos.py
+++ b/cmms_fabrica/crud/crud_calibraciones_instrumentos.py
@@ -15,7 +15,6 @@ import pandas as pd
 from datetime import datetime, timedelta
 from modulos.conexion_mongo import db
 from crud.generador_historial import registrar_evento_historial
-import time
 
 coleccion = db["calibraciones"]
 activos = db["activos_tecnicos"]

--- a/cmms_fabrica/crud/dashboard_kpi_historial.py
+++ b/cmms_fabrica/crud/dashboard_kpi_historial.py
@@ -11,7 +11,6 @@ que consolida eventos preventivos, correctivos, técnicos, observaciones y calib
 """
 
 import streamlit as st
-from pymongo import MongoClient
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates

--- a/cmms_fabrica/modulos/almacenamiento.py
+++ b/cmms_fabrica/modulos/almacenamiento.py
@@ -1,7 +1,4 @@
-import pymongo
-import os
 from datetime import datetime
-from dotenv import load_dotenv
 from crud.generador_historial import registrar_evento_historial
 from modulos.conexion_mongo import db
 


### PR DESCRIPTION
## Summary
- clean unused imports from the storage module
- drop leftover `MongoClient` import from KPI dashboard
- trim unused `time` import from calibration module

## Testing
- `pytest -q` *(fails: ConfigurationError when connecting to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_685f31ee8030832ba57d3b544d52ac92