### PR TITLE
Implementador de ID común

### DIFF
--- a/cmms_fabrica/crud/crud_calibraciones_instrumentos.py
+++ b/cmms_fabrica/crud/crud_calibraciones_instrumentos.py
@@ -14,14 +14,12 @@ import streamlit as st
 import pandas as pd
 from datetime import datetime, timedelta
 from modulos.conexion_mongo import db
-from crud.generador_historial import registrar_evento_historial
+from crud.generador_historial import generar_id, registrar_evento_historial
 import time
 
 coleccion = db["calibraciones"]
 activos = db["activos_tecnicos"]
 
-def generar_id_calibracion():
-    return f"CAL-{int(datetime.now().timestamp())}"
 
 
 def form_calibracion(defaults=None):
@@ -31,9 +29,12 @@ def form_calibracion(defaults=None):
         return None
 
     with st.form("form_calibracion"):
-        id_activo = st.selectbox("ID del Instrumento", ids_activos,
-                                 index=ids_activos.index(defaults["id_activo_tecnico"]) if defaults and defaults.get("id_activo_tecnico") in ids_activos else 0)
-        id_calibracion = defaults.get("id_calibracion") if defaults else generar_id_calibracion()
+        id_activo = st.selectbox(
+            "ID del Instrumento",
+            ids_activos,
+            index=ids_activos.index(defaults["id_activo_tecnico"]) if defaults and defaults.get("id_activo_tecnico") in ids_activos else 0,
+        )
+        id_calibracion = defaults.get("id_calibracion") if defaults else generar_id("CAL")
 
         fecha_cal = st.date_input("Fecha de Calibración", value=defaults.get("fecha_calibracion") if defaults else datetime.today())
         responsable = st.text_input("Responsable de Calibración", value=defaults.get("responsable") if defaults else "")

--- a/cmms_fabrica/crud/crud_planes_preventivos.py
+++ b/cmms_fabrica/crud/crud_planes_preventivos.py
@@ -14,13 +14,9 @@ Cada acción se registra en la colección `historial` para trazabilidad operativ
 import streamlit as st
 from datetime import datetime
 from modulos.conexion_mongo import db
-from crud.generador_historial import registrar_evento_historial
+from crud.generador_historial import generar_id, registrar_evento_historial
 
 coleccion = db["planes_preventivos"]
-
-def generar_id_plan():
-    return f"PP-{int(datetime.now().timestamp())}"
-
 
 def app():
     st.title("🗓️ Gestión de Planes Preventivos")
@@ -30,7 +26,10 @@ def app():
 
     def form_plan(defaults=None):
         with st.form("form_plan_preventivo"):
-            id_plan = st.text_input("ID del Plan", value=defaults.get("id_plan") if defaults else generar_id_plan())
+            id_plan = st.text_input(
+                "ID del Plan",
+                value=defaults.get("id_plan") if defaults else generar_id("PP"),
+            )
 
             activos = db["activos_tecnicos"]
             activos_lista = list(activos.find({}, {"_id": 0, "id_activo_tecnico": 1, "nombre": 1, "pertenece_a": 1}))

--- a/cmms_fabrica/crud/crud_tareas_correctivas.py
+++ b/cmms_fabrica/crud/crud_tareas_correctivas.py
@@ -13,12 +13,10 @@ Registra automáticamente en la colección `historial` cada evento para asegurar
 import streamlit as st
 from datetime import datetime
 from modulos.conexion_mongo import db
-from crud.generador_historial import registrar_evento_historial
+from crud.generador_historial import generar_id, registrar_evento_historial
 
 coleccion = db["tareas_correctivas"]
 
-def generar_id_tarea():
-    return f"TC-{int(datetime.now().timestamp())}"
 
 
 def form_tarea(defaults=None):
@@ -30,7 +28,7 @@ def form_tarea(defaults=None):
         index_default = ids_activos.index(id_default) if id_default in ids_activos else 0 if ids_activos else -1
 
         id_activo = st.selectbox("ID del Activo Técnico", ids_activos, index=index_default) if ids_activos else st.text_input("ID del Activo Técnico")
-        id_tarea = defaults.get("id_tarea") if defaults else generar_id_tarea()
+        id_tarea = defaults.get("id_tarea") if defaults else generar_id("TC")
 
         fecha_evento = st.date_input("Fecha del Evento", value=defaults.get("fecha_evento") if defaults else datetime.today())
         descripcion_falla = st.text_area("Descripción de la Falla", value=defaults.get("descripcion_falla") if defaults else "")

--- a/cmms_fabrica/crud/crud_tareas_tecnicas.py
+++ b/cmms_fabrica/crud/crud_tareas_tecnicas.py
@@ -12,12 +12,10 @@ Se registran automáticamente en la colección `historial` para trazabilidad.
 import streamlit as st
 from datetime import datetime
 from modulos.conexion_mongo import db
-from crud.generador_historial import registrar_evento_historial
+from crud.generador_historial import generar_id, registrar_evento_historial
 
 coleccion = db["tareas_tecnicas"]
 
-def generar_id_tarea_tecnica():
-    return f"TT-{int(datetime.now().timestamp())}"
 
 
 def form_tecnica(defaults=None):
@@ -39,7 +37,7 @@ def form_tecnica(defaults=None):
 
         seleccion_visible = st.selectbox("ID del Activo Técnico (opcional)", ids_visibles, index=index_default)
         id_activo = next((k for k, v in id_map.items() if v == seleccion_visible), seleccion_visible) if seleccion_visible else ""
-        id_tarea_tecnica = defaults.get("id_tarea_tecnica") if defaults else generar_id_tarea_tecnica()
+        id_tarea_tecnica = defaults.get("id_tarea_tecnica") if defaults else generar_id("TT")
 
         fecha_evento = st.date_input("📆 Fecha del Evento", value=defaults.get("fecha_evento", hoy) if defaults else hoy)
         fecha_inicio = st.date_input("🗕️ Fecha de Inicio", value=defaults.get("fecha_inicio", fecha_evento) if defaults else fecha_evento)

--- a/cmms_fabrica/crud/generador_historial.py
+++ b/cmms_fabrica/crud/generador_historial.py
@@ -10,6 +10,11 @@ from datetime import datetime
 import logging
 from modulos.conexion_mongo import db
 
+
+def generar_id(prefijo: str) -> str:
+    """Devuelve un identificador con el prefijo dado y timestamp."""
+    return f"{prefijo}-{int(datetime.now().timestamp())}"
+
 logger = logging.getLogger(__name__)
 
 def registrar_evento_historial(


### PR DESCRIPTION
## Summary
- add `generar_id` helper in `generador_historial`
- replace older ID helpers with calls to `generar_id`

## Testing
- `pytest -q` *(fails: ServerSelectionTimeoutError - no MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_685f31f365d0832b92a619c7133d4b77