### PR TITLE
Improve MongoDB availability check

### DIFF
--- a/cmms_fabrica/crud/generador_historial.py
+++ b/cmms_fabrica/crud/generador_historial.py
@@ -27,6 +27,10 @@ def registrar_evento_historial(
     de acuerdo con ISO 9001.
     """
 
+    if db is None:
+        logger.warning("MongoDB no disponible. Evento no registrado.")
+        return ""
+
     historial = db["historial"]
 
     evento = {


### PR DESCRIPTION
## Summary
- avoid failing when MongoDB isn't available by checking for a connection before logging events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686076238d14832ba9698513b8d98bcd