### PR TITLE
Refactor layout for user management

### DIFF
--- a/cmms_fabrica/modulos/app_usuarios.py
+++ b/cmms_fabrica/modulos/app_usuarios.py
@@ -1,13 +1,24 @@
+"""Gestión de usuarios del CMMS.
+
+Este módulo permite registrar, visualizar, editar y eliminar usuarios del
+sistema. Su implementación sigue las buenas prácticas de trazabilidad
+documental establecidas en ISO 9001:2015 y considera directrices de
+seguridad basadas en ISO 27001.
+"""
+
 import streamlit as st
 import pandas as pd
+
 from .conexion_mongo import db
 from .app_login import hash_password
 
 coleccion = db["usuarios"]
 
 
-def app_usuarios(usuario_logueado, rol_logueado):
-    st.subheader("👤 Gestión de Usuarios del Sistema")
+def app_usuarios(usuario_logueado: str, rol_logueado: str) -> None:
+    """Interfaz principal para administrar los usuarios."""
+
+    st.title("👥 Gestión de Usuarios del Sistema")
 
     if rol_logueado != "admin":
         st.warning("Acceso restringido. Solo administradores pueden ver este módulo.")
@@ -16,19 +27,18 @@ def app_usuarios(usuario_logueado, rol_logueado):
     datos = list(coleccion.find({}, {"_id": 0}))
     df = pd.DataFrame(datos)
 
-    tabs = st.tabs(["📄 Ver Usuarios", "🛠️ Administrar Usuarios"])
+    menu = ["Registrar Usuario", "Ver Usuarios", "Editar Usuario", "Eliminar Usuario"]
+    accion = st.sidebar.radio("Acción", menu)
 
-    # --- TAB 1: VER ---
-    with tabs[0]:
+    if accion == "Ver Usuarios":
         if df.empty:
             st.info("No hay usuarios registrados.")
         else:
             st.dataframe(df.drop(columns=["password_hash"]), use_container_width=True)
 
-    # --- TAB 2: ADMINISTRAR ---
-    with tabs[1]:
-        st.markdown("### ➕ Crear nuevo usuario")
-        with st.form("form_usuario"):
+    elif accion == "Registrar Usuario":
+        st.subheader("➕ Crear nuevo usuario")
+        with st.form("form_nuevo_usuario"):
             nuevo_usuario = st.text_input("Nombre de usuario").strip().lower()
             nueva_clave = st.text_input("Contraseña", type="password")
             rol = st.selectbox("Rol", ["admin", "tecnico", "produccion", "invitado"])
@@ -43,36 +53,45 @@ def app_usuarios(usuario_logueado, rol_logueado):
                 nuevo = {
                     "usuario": nuevo_usuario,
                     "password_hash": hash_password(nueva_clave),
-                    "rol": rol
+                    "rol": rol,
                 }
                 coleccion.insert_one(nuevo)
                 st.success(f"✅ Usuario '{nuevo_usuario}' creado correctamente.")
                 st.rerun()
 
-        st.divider()
-        st.markdown("### ✏️ Modificar o eliminar usuario")
-        if not df.empty:
-            usuario_sel = st.selectbox("Seleccionar usuario", [u for u in df["usuario"].tolist() if u != usuario_logueado])
-            col1, col2 = st.columns([2, 1])
-
-            with col1.form("form_pass"):
+    elif accion == "Editar Usuario":
+        st.subheader("✏️ Modificar contraseña de usuario")
+        if df.empty:
+            st.info("No hay usuarios registrados.")
+        else:
+            usuario_sel = st.selectbox(
+                "Seleccionar usuario",
+                [u for u in df["usuario"].tolist() if u != usuario_logueado],
+            )
+            with st.form("form_actualizar_pass"):
                 nueva_pass = st.text_input("Nueva contraseña", type="password")
                 cambiar = st.form_submit_button("Actualizar contraseña")
-            with col2.form("form_borrar"):
-                eliminar = st.form_submit_button("🗑️ Eliminar usuario")
-
             if cambiar:
                 if not nueva_pass:
                     st.error("⚠️ La nueva contraseña no puede estar vacía.")
                 else:
                     coleccion.update_one(
                         {"usuario": usuario_sel},
-                        {"$set": {"password_hash": hash_password(nueva_pass)}}
+                        {"$set": {"password_hash": hash_password(nueva_pass)}},
                     )
                     st.success("✅ Contraseña actualizada.")
                     st.rerun()
 
-            if eliminar:
+    elif accion == "Eliminar Usuario":
+        st.subheader("🗑️ Eliminar usuario")
+        if df.empty:
+            st.info("No hay usuarios registrados.")
+        else:
+            usuario_sel = st.selectbox(
+                "Seleccionar usuario",
+                [u for u in df["usuario"].tolist() if u != usuario_logueado],
+            )
+            if st.button("Eliminar usuario seleccionado"):
                 coleccion.delete_one({"usuario": usuario_sel})
                 st.success(f"🗑️ Usuario '{usuario_sel}' eliminado.")
                 st.rerun()


### PR DESCRIPTION
## Summary
- align `app_usuarios` module with CMMS layout and add ISO references
- use sidebar menu for viewing, creating, editing and removing users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608166eb80832b8299c73a698286c8