### PR TITLE
Fix relative imports in CMMS package

### DIFF
--- a/cmms_fabrica/app.py
+++ b/cmms_fabrica/app.py
@@ -2,32 +2,32 @@ import streamlit as st
 st.set_page_config(page_title="CMMS Fábrica", layout="wide")
 
 # 🔐 Login y cierre de sesión
-from modulos.app_login import login_usuario, cerrar_sesion
-from modulos.conexion_mongo import db
+from cmms_fabrica.modulos.app_login import login_usuario, cerrar_sesion
+from cmms_fabrica.modulos.conexion_mongo import db
 
 # 💄 Estilos responsive
-from modulos.estilos import aplicar_estilos
+from cmms_fabrica.modulos.estilos import aplicar_estilos
 
 
 # Nuevos módulos CRUD centrados en activos técnicos
-from crud.crud_activos_tecnicos import app as crud_activos_tecnicos
-from crud.crud_planes_preventivos import app as crud_planes_preventivos
-from crud.crud_tareas_correctivas import app as crud_tareas_correctivas
-from crud.crud_tareas_tecnicas import app as crud_tareas_tecnicas
-from crud.crud_observaciones import app as crud_observaciones
-from crud.crud_calibraciones_instrumentos import app as crud_calibraciones
-from crud.crud_servicios_externos import app as crud_servicios
-from crud.dashboard_kpi_historial import app as kpi_historial
-from crud.crud_inventario import app_inventario
+from cmms_fabrica.crud.crud_activos_tecnicos import app as crud_activos_tecnicos
+from cmms_fabrica.crud.crud_planes_preventivos import app as crud_planes_preventivos
+from cmms_fabrica.crud.crud_tareas_correctivas import app as crud_tareas_correctivas
+from cmms_fabrica.crud.crud_tareas_tecnicas import app as crud_tareas_tecnicas
+from cmms_fabrica.crud.crud_observaciones import app as crud_observaciones
+from cmms_fabrica.crud.crud_calibraciones_instrumentos import app as crud_calibraciones
+from cmms_fabrica.crud.crud_servicios_externos import app as crud_servicios
+from cmms_fabrica.crud.dashboard_kpi_historial import app as kpi_historial
+from cmms_fabrica.crud.crud_inventario import app_inventario
 
 # Módulo de usuarios (admin)
-from modulos.app_usuarios import app_usuarios
+from cmms_fabrica.modulos.app_usuarios import app_usuarios
 
 # Gestión de IDs manuales
-from modulos.cambiar_ids import app as cambiar_ids
+from cmms_fabrica.modulos.cambiar_ids import app as cambiar_ids
 
 # Reportes técnicos
-from modulos.app_reportes import app as app_reportes
+from cmms_fabrica.modulos.app_reportes import app as app_reportes
 
 # 📱 Estilos responsive
 aplicar_estilos()

--- a/cmms_fabrica/crud/crud_activos_tecnicos.py
+++ b/cmms_fabrica/crud/crud_activos_tecnicos.py
@@ -12,8 +12,8 @@ Registra automáticamente los eventos en la colección `historial` para trazabil
 
 import streamlit as st
 from datetime import datetime
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["activos_tecnicos"]
 

--- a/cmms_fabrica/crud/crud_calibraciones_instrumentos.py
+++ b/cmms_fabrica/crud/crud_calibraciones_instrumentos.py
@@ -13,8 +13,8 @@ Permite registrar, visualizar, editar y eliminar calibraciones, mostrando alerta
 import streamlit as st
 import pandas as pd
 from datetime import datetime, timedelta
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["calibraciones"]
 activos = db["activos_tecnicos"]

--- a/cmms_fabrica/crud/crud_inventario.py
+++ b/cmms_fabrica/crud/crud_inventario.py
@@ -10,8 +10,8 @@ trazabilidad según ISO 9001 e ISO 55001.
 import pandas as pd
 import streamlit as st
 from datetime import datetime
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["inventario"]
 

--- a/cmms_fabrica/crud/crud_observaciones.py
+++ b/cmms_fabrica/crud/crud_observaciones.py
@@ -13,8 +13,8 @@ Registra automáticamente cada evento en la colección `historial` para trazabil
 
 import streamlit as st
 from datetime import datetime
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["observaciones"]
 activos = db["activos_tecnicos"]

--- a/cmms_fabrica/crud/crud_planes_preventivos.py
+++ b/cmms_fabrica/crud/crud_planes_preventivos.py
@@ -13,8 +13,8 @@ Cada acción se registra en la colección `historial` para trazabilidad operativ
 
 import streamlit as st
 from datetime import datetime
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["planes_preventivos"]
 

--- a/cmms_fabrica/crud/crud_servicios_externos.py
+++ b/cmms_fabrica/crud/crud_servicios_externos.py
@@ -11,8 +11,8 @@ Cada cambio se documenta automáticamente en la colección `historial`.
 
 import streamlit as st
 from datetime import datetime
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["servicios_externos"]
 

--- a/cmms_fabrica/crud/crud_tareas_correctivas.py
+++ b/cmms_fabrica/crud/crud_tareas_correctivas.py
@@ -12,8 +12,8 @@ Registra automáticamente en la colección `historial` cada evento para asegurar
 
 import streamlit as st
 from datetime import datetime
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["tareas_correctivas"]
 

--- a/cmms_fabrica/crud/crud_tareas_tecnicas.py
+++ b/cmms_fabrica/crud/crud_tareas_tecnicas.py
@@ -11,8 +11,8 @@ Se registran automáticamente en la colección `historial` para trazabilidad.
 
 import streamlit as st
 from datetime import datetime
-from ..modulos.conexion_mongo import db
-from .generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 coleccion = db["tareas_tecnicas"]
 

--- a/cmms_fabrica/crud/dashboard_kpi_historial.py
+++ b/cmms_fabrica/crud/dashboard_kpi_historial.py
@@ -15,7 +15,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from datetime import datetime
-from ..modulos.conexion_mongo import db
+from cmms_fabrica.modulos.conexion_mongo import db
 
 coleccion = db["historial"]
 activos_tecnicos = db["activos_tecnicos"]

--- a/cmms_fabrica/crud/generador_historial.py
+++ b/cmms_fabrica/crud/generador_historial.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from ..modulos.conexion_mongo import db
+from cmms_fabrica.modulos.conexion_mongo import db
 
 logger = logging.getLogger(__name__)
 

--- a/cmms_fabrica/modulos/almacenamiento.py
+++ b/cmms_fabrica/modulos/almacenamiento.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Dict, Literal
 
-from ..crud.generador_historial import registrar_evento_historial
-from .conexion_mongo import db
+from cmms_fabrica.crud.generador_historial import registrar_evento_historial
+from cmms_fabrica.modulos.conexion_mongo import db
 
 LIMITE_MB: int = 400
 

--- a/cmms_fabrica/modulos/app_kpi.py
+++ b/cmms_fabrica/modulos/app_kpi.py
@@ -1,6 +1,6 @@
 import streamlit as st
 import pandas as pd
-from .conexion_mongo import db
+from cmms_fabrica.modulos.conexion_mongo import db
 
 def cargar_coleccion(nombre):
     df = pd.DataFrame(list(db[nombre].find({}, {"_id": 0})))

--- a/cmms_fabrica/modulos/app_login.py
+++ b/cmms_fabrica/modulos/app_login.py
@@ -2,7 +2,7 @@ import streamlit as st
 import hashlib
 import secrets
 import time
-from .conexion_mongo import db
+from cmms_fabrica.modulos.conexion_mongo import db
 
 coleccion = db["usuarios"]
 

--- a/cmms_fabrica/modulos/app_reportes.py
+++ b/cmms_fabrica/modulos/app_reportes.py
@@ -13,7 +13,7 @@ import streamlit as st
 import pandas as pd
 from fpdf import FPDF
 from datetime import datetime, date
-from .conexion_mongo import db
+from cmms_fabrica.modulos.conexion_mongo import db
 import os
 from io import BytesIO
 

--- a/cmms_fabrica/modulos/app_usuarios.py
+++ b/cmms_fabrica/modulos/app_usuarios.py
@@ -9,8 +9,8 @@ seguridad basadas en ISO 27001.
 import streamlit as st
 import pandas as pd
 
-from .conexion_mongo import db
-from .app_login import hash_password
+from cmms_fabrica.modulos.conexion_mongo import db
+from cmms_fabrica.modulos.app_login import hash_password
 
 coleccion = db["usuarios"]
 

--- a/cmms_fabrica/modulos/cambiar_ids.py
+++ b/cmms_fabrica/modulos/cambiar_ids.py
@@ -1,7 +1,7 @@
 """Herramienta para actualizar IDs de documentos en múltiples colecciones."""
 
 import streamlit as st
-from .conexion_mongo import db
+from cmms_fabrica.modulos.conexion_mongo import db
 
 # Diccionario de colecciones, campos editables y rutas de actualización
 EDITABLES = {


### PR DESCRIPTION
## Summary
- use absolute imports across cmms_fabrica modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686086024f88832ba6c2a4560b0e0fef