### PR TITLE
Improve report messages and ID validation

### DIFF
--- a/cmms_fabrica/crud/generador_historial.py
+++ b/cmms_fabrica/crud/generador_historial.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 def registrar_evento_historial(
     tipo_evento: str,
     id_activo: str | None,
-    id_origen: str,
+    id_origen: str | None = None,
     descripcion: str,
     usuario: str,
     proveedor_externo: str | None = None,
@@ -38,7 +38,7 @@ def registrar_evento_historial(
         "id_activo_tecnico": id_activo,
         "fecha_evento": datetime.now(),
         "tipo_evento": tipo_evento,
-        "id_origen": id_origen,
+        "id_origen": id_origen or "HUÉRFANO",
         "descripcion": descripcion,
         "usuario_registro": usuario,
         "proveedor_externo": proveedor_externo,


### PR DESCRIPTION
## Summary
- display orphan ID when missing in PDF reports
- default `id_origen` as `HUÉRFANO` in event logs
- refine report dataframe handling of `id_origen`
- show styled message when no inventory movement
- disable export buttons when there is no data
- add backward compatible `filtrar_ultimo_por_activo`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mongomock')*

------
https://chatgpt.com/codex/tasks/task_e_6886c140b8a8832ba58df5ccd2e099e8