### PR TITLE
Fix filtering in technical reports

### DIFF
--- a/cmms_fabrica/modulos/app_reportes.py
+++ b/cmms_fabrica/modulos/app_reportes.py
@@ -92,17 +92,19 @@ def generar_excel(df_eventos, df_inventario):
     output.seek(0)
     return output
 
-# 🔍 Filtrar última actualización por tarea
-def filtrar_ultimo_por_tarea(df):
-    if "id_origen" not in df or "fecha_evento" not in df:
+# 🔍 Filtrar última actualización por tarea y activo técnico
+def filtrar_ultimo_por_tarea_y_activo(df):
+    """Devuelve la última entrada por combinación de activo técnico y tarea."""
+    if "id_origen" not in df or "id_activo_tecnico" not in df or "fecha_evento" not in df:
         return df
     df_ordenado = df.sort_values("fecha_evento", ascending=False)
-    idx = df_ordenado.groupby("id_origen")["fecha_evento"].idxmax()
+    idx = df_ordenado.groupby(["id_activo_tecnico", "id_origen"])["fecha_evento"].idxmax()
     return df_ordenado.loc[idx].reset_index(drop=True)
 
 # Compatibilidad con versiones anteriores
 def filtrar_ultimo_por_activo(df):
-    return filtrar_ultimo_por_tarea(df)
+    """Mantiene compatibilidad con versiones que agrupaban solo por tarea."""
+    return filtrar_ultimo_por_tarea_y_activo(df)
 
 # 🚀 Interfaz principal
 def app():
@@ -152,7 +154,7 @@ def app():
     df["usuario_registro"] = df["usuario_registro"].fillna("desconocido")
     df["id_origen"] = df["id_origen"].replace("-", "").fillna("HUÉRFANO")
 
-    df_filtrado = filtrar_ultimo_por_tarea(df)
+    df_filtrado = filtrar_ultimo_por_tarea_y_activo(df)
 
     columnas = ["fecha_evento", "tipo_evento", "id_activo_tecnico", "id_origen", "descripcion", "usuario_registro", "observaciones"]
     for col in columnas:

--- a/tests/test_reportes.py
+++ b/tests/test_reportes.py
@@ -37,3 +37,24 @@ def test_filtrar_ultimo_por_evento():
     filtrado = filtrar_ultimo_por_activo(df)
     assert len(filtrado) == 1
     assert filtrado.iloc[0]["descripcion"] == "segundo"
+
+
+def test_filtrar_por_tarea_y_activo():
+    df = pd.DataFrame(
+        {
+            "fecha_evento": [
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-03"),
+                pd.Timestamp("2024-01-05"),
+            ],
+            "tipo_evento": ["test", "test", "test"],
+            "id_activo_tecnico": ["A1", "A2", "A1"],
+            "id_origen": ["EV1", "EV1", "EV1"],
+            "descripcion": ["a1-1", "a2-1", "a1-2"],
+            "usuario_registro": ["u", "u", "u"],
+        }
+    )
+    filtrado = filtrar_ultimo_por_activo(df)
+    assert len(filtrado) == 2
+    assert set(filtrado["id_activo_tecnico"]) == {"A1", "A2"}
+    assert filtrado.sort_values("id_activo_tecnico").iloc[1]["descripcion"] == "a1-2"


### PR DESCRIPTION
## Summary
- filter last record by both task and technical asset
- adjust call site and maintain backward compatibility
- extend tests for new filtering logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mongomock')*

------
https://chatgpt.com/codex/tasks/task_e_6886d0d96b70832bb6fffe6185316ece