### PR TITLE
Unify visual style across CRUD listings

### DIFF
--- a/cmms_fabrica/crud/crud_servicios_externos.py
+++ b/cmms_fabrica/crud/crud_servicios_externos.py
@@ -83,20 +83,26 @@ def app():
             st.info("No hay proveedores cargados.")
             return
 
-        df = pd.DataFrame(proveedores)
-        df.drop(columns=["_id"], inplace=True, errors="ignore")
+        texto_filtro = st.text_input("🔍 Buscar por nombre o ID")
 
-        query = st.text_input("Buscar...")
-        df_filtered = (
-            df[df.astype(str).apply(lambda row: query.lower() in row.str.lower().to_string(), axis=1)]
-            if query
-            else df
-        )
+        filtrados = []
+        for p in proveedores:
+            texto = (
+                p.get("nombre", "")
+                + p.get("id_proveedor", "")
+                + p.get("especialidad", "")
+            )
+            if texto_filtro.lower() in texto.lower():
+                filtrados.append(p)
 
-        if df_filtered.empty:
-            st.info("🔍 No se encontraron registros")
+        if not filtrados:
+            st.warning("No se encontraron registros con esos filtros.")
         else:
-            st.dataframe(df_filtered, use_container_width=True)
+            for p in filtrados:
+                st.code(f"ID Proveedor: {p.get('id_proveedor', '')}", language="yaml")
+                st.markdown(
+                    f"- **{p.get('nombre', '')}** ({p.get('especialidad', '')})"
+                )
 
     elif choice == "Editar Proveedor":
         st.subheader("✏️ Editar Proveedor Técnico")

--- a/cmms_fabrica/modulos/app_usuarios.py
+++ b/cmms_fabrica/modulos/app_usuarios.py
@@ -33,7 +33,9 @@ def app_usuarios(usuario_logueado: str, rol_logueado: str) -> None:
         if df.empty:
             st.info("No hay usuarios registrados.")
         else:
-            st.dataframe(df.drop(columns=["password_hash"]), use_container_width=True)
+            for u in sorted(datos, key=lambda x: x.get("usuario", "")):
+                st.code(f"Usuario: {u.get('usuario', '')}", language="yaml")
+                st.markdown(f"- **Rol:** {u.get('rol', '')}")
 
     elif accion == "Registrar Usuario":
         st.subheader("➕ Crear Nuevo Usuario")


### PR DESCRIPTION
## Summary
- apply "lista detallada" view to preventive plans, corrective tasks, technical tasks and more
- show detailed blocks for observations, calibrations and services
- render admin users list using the same style

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mongomock')*

------
https://chatgpt.com/codex/tasks/task_e_6886d5d00d00832bbb83dffbcf9c35d1