### PR TITLE
docs: auditar y alinear repo con fuentes oficiales; actualizar README, setup, checklist y labels UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,125 +1,131 @@
-🏭 CMMS Fábrica – Portable
+# 🏭 CMMS Fábrica – Portable
 
 CMMS orientado a mantenimiento industrial con trazabilidad operativa e integración con MongoDB.
 
-🧭 Modelo conceptual vigente
+## 🧭 Modelo conceptual vigente (fuentes en `/docs`)
 
 La aplicación se alinea con dos vistas complementarias:
 
-Jerarquía técnica:
-Sistema > Subsistema > Equipo
+- **Jerarquía técnica:** Sistema → Subsistema → Equipo
+- **Nivel funcional:** Proceso → Activo → Componente
 
-Nivel funcional:
-Proceso > Activo > Componente
+Este modelo convive con el esquema operativo actual para conservar compatibilidad histórica.
 
-Este modelo conceptual convive con el esquema operativo actual de la aplicación para mantener compatibilidad con datos históricos.
+## 🔒 Compatibilidad de datos (sin ruptura)
 
-🔒 Compatibilidad de datos (sin ruptura)
-El campo pertenece_a se mantiene como relación padre operativa vigente entre registros
-El campo nivel (cuando exista en el registro) representa la jerarquía técnica (sistema, subsistema, equipo)
-No se requieren renombres de colecciones ni migraciones masivas
-🧱 Núcleo CMMS
+Para evitar migraciones silenciosas:
 
-Módulos centrados en la gestión técnica de activos y mantenimiento:
+- Se mantiene **`pertenece_a`** como relación padre operativa vigente.
+- Se usa **`nivel`** (cuando existe) para expresar jerarquía técnica.
+- Se conserva **`tipo`** como campo persistido en activos (equivalente operativo de `tipo_activo` conceptual).
+- No se renombraron colecciones persistidas ni campos críticos existentes.
 
-Activos técnicos
-Planes preventivos
-Tareas correctivas
-Tareas técnicas
-Observaciones técnicas
-Calibraciones
-Servicios técnicos
-🧩 Módulos auxiliares (no núcleo conceptual)
+## 🧱 Núcleo CMMS (implementación activa)
 
-Estos módulos se mantienen como soporte de operación y análisis:
+- Activos técnicos
+- Planes preventivos
+- Tareas correctivas
+- Tareas técnicas
+- Observaciones técnicas
+- Calibraciones
+- Servicios técnicos externos
+- Historial técnico
+- Usuarios y roles
 
-Inventario técnico
-Consumos técnicos
-Grafo CMMS
-Reportes técnicos
-KPIs y tablero de seguimiento
-✅ Capacidades principales
-CRUD completo por dominio técnico
-Trazabilidad mediante colección historial
-Gestión de usuarios y roles
-Integración con MongoDB (conexion_mongo.py)
-Alineación con ISO 55001, ISO 14224 e ISO 9001
-🛠️ Ejecución local
+## 🧩 Módulos auxiliares (soporte operativo)
+
+- Inventario técnico
+- Consumos técnicos
+- Grafo CMMS
+- Reportes técnicos
+- KPIs y tablero de seguimiento
+- Asistentes técnicos (IA)
+
+## ✅ Capacidades principales
+
+- CRUD por dominio técnico.
+- Registro de trazabilidad en colección `historial`.
+- Gestión de usuarios y roles.
+- Integración con MongoDB (`conexion_mongo.py`).
+- Alineación operativa con ISO 55001, ISO 14224 e ISO 9001.
+
+## 🛠️ Ejecución local
 
 Instalar dependencias:
 
+```bash
 pip install -r cmms_fabrica/requirements.txt
+```
 
-Definir variables de entorno en .env:
+Definir variables de entorno en `.env`:
 
+```bash
 MONGO_URI=mongodb://<host>:<puerto>/
 DB_NAME=cmms
+```
 
 Ejecutar la app:
 
+```bash
 streamlit run cmms_fabrica/app.py
+```
 
-(Opcional) pruebas:
+Pruebas (opcional):
 
+```bash
 pip install -r cmms_fabrica/requirements-dev.txt
-PYTHONPATH=cmms_fabrica pytest -q
+PYTHONPATH=. pytest -q
+```
 
-🔄 Lógica de operación
+## 🔄 Lógica de operación
 
-Detectar → Ejecutar → Registrar → Validar → Mejorar
+Detectar → Analizar → Ejecutar → Registrar → Validar → Mejorar
 
 Revisión obligatoria cada 15 días.
 
-⚠️ Criterio de priorización
+## ⚠️ Criterio de priorización
 
 Las intervenciones se priorizan según criticidad:
 
-🔴 Crítico → parada de línea o riesgo de seguridad
-🟠 Alto → impacto en producción
-🟡 Medio → degradación del rendimiento
-🟢 Bajo → sin impacto relevante
+- 🔴 Crítico → parada de línea o riesgo de seguridad.
+- 🟠 Alto → impacto en producción.
+- 🟡 Medio → degradación del rendimiento.
+- 🟢 Bajo → sin impacto relevante.
 
-La criticidad se evalúa en base a:
+La criticidad se evalúa con:
 
-Impacto en producción
-Riesgo de seguridad
-Estado del activo
-Reincidencia
+- Impacto en producción
+- Riesgo de seguridad
+- Estado del activo
+- Reincidencia
 
-La criticidad define prioridad, no urgencia percibida.
+La criticidad define prioridad (no urgencia percibida).
 
-🎯 Filosofía de uso
-El CMMS es la única fuente de verdad
-Toda acción se registra
-Simplicidad > complejidad
-El sistema se adapta al técnico
-La mejora se basa en lo ejecutado
-📋 Tipos de tareas
-Correctivas → fallas reales + RCA
-Preventivas → tareas planificadas
-Técnicas → análisis y gestión
-Observaciones → hallazgos
-📊 Resultado esperado
+## 🎯 Filosofía de uso
 
-Sistema:
+- El CMMS es la única fuente de verdad.
+- Toda acción se registra.
+- Simplicidad > complejidad.
+- El sistema se adapta al técnico.
+- La mejora se basa en lo ejecutado.
 
-Ordenado
-Trazable
-Repetible
-Aplicable en cualquier fábrica
-📋 Normas
+## 📋 Tipos de tareas
+
+- Correctivas → fallas reales + RCA
+- Preventivas → tareas planificadas
+- Técnicas → análisis y gestión
+- Observaciones → hallazgos
+
+## 📋 Normas
 
 Alineado con:
 
-ISO 55001
-ISO 9001
-ISO 14224
-🌱 Escalabilidad
-Integración con sensores (IoT)
-Automatización
-IA sobre historial
-👤 Autor
+- ISO 55001
+- ISO 9001
+- ISO 14224
+
+## 👤 Autor
 
 Pablo Lepratti
 
-“El sistema no representa la fábrica. Representa cómo el técnico la entiende.”
+> “El sistema no representa la fábrica. Representa cómo el técnico la entiende.”

--- a/cmms_fabrica/crud/crud_activos_tecnicos.py
+++ b/cmms_fabrica/crud/crud_activos_tecnicos.py
@@ -66,7 +66,12 @@ def app():
             id_activo = st.text_input("ID del Activo Técnico", value=defaults.get("id_activo_tecnico") if defaults else "")
             nombre = st.text_input("Nombre o Descripción", value=defaults.get("nombre") if defaults else "")
             ubicacion = st.text_input("Ubicación", value=defaults.get("ubicacion") if defaults else "")
-            tipo = st.selectbox("Tipo de Activo", opciones_tipo, index=tipo_index)
+            tipo = st.selectbox(
+                "Tipo de Activo (campo operativo: tipo)",
+                opciones_tipo,
+                index=tipo_index,
+                help="Equivale al concepto `tipo_activo` definido en las fuentes oficiales.",
+            )
             estado = st.selectbox("Estado", opciones_estado, index=estado_index)
 
             activos_existentes = list(coleccion.find({}, {"_id": 0, "id_activo_tecnico": 1}))
@@ -75,7 +80,7 @@ def app():
             valor_default = defaults.get("pertenece_a") if defaults else ""
             index_default = ids_disponibles.index(valor_default) if valor_default in ids_disponibles else 0
             pertenece_a = st.selectbox(
-                "Activo padre / Proceso padre (opcional)",
+                "Activo padre / Proceso padre (campo operativo: pertenece_a)",
                 options=ids_disponibles,
                 index=index_default,
                 help="Usa este campo para vincular el registro a su padre operativo. Se guarda en `pertenece_a`.",

--- a/docs/alineacion_repo_fuentes.md
+++ b/docs/alineacion_repo_fuentes.md
@@ -1,0 +1,58 @@
+# Alineación Repo ↔ Fuentes Oficiales (/docs)
+
+Fecha de auditoría: 2026-04-05.
+
+## Estado actual de alineación
+
+### 1) Alineado
+
+- Colecciones núcleo operativas presentes en código: `activos_tecnicos`, `planes_preventivos`, `tareas_correctivas`, `tareas_tecnicas`, `observaciones`, `calibraciones`, `servicios_externos`, `historial`, `usuarios`.
+- Enfoque de trazabilidad con `historial` implementado y utilizado por módulos CRUD.
+- Jerarquía técnica representada operativamente mediante `nivel` (opcional) y relación padre mediante `pertenece_a`.
+- Estructura general de módulos (`crud/`, `modulos/`) coincide con lo definido en la documentación técnica del repositorio.
+
+### 2) Parcialmente alineado
+
+- **Modelo conceptual vs. persistencia**:
+  - Fuentes oficiales usan `tipo_activo` y `activo_padre`.
+  - Código vigente persiste `tipo` y `pertenece_a`.
+  - Se mantiene compatibilidad, pero requiere mapeo explícito en documentación.
+- **Regla de criticidad obligatoria**:
+  - Las fuentes operativas indican criticidad obligatoria en correctivas/observaciones.
+  - El código no exige campo de criticidad persistido en todos los formularios.
+- **Trazabilidad homogénea**:
+  - Existe `CMMSRepository` con validación de `id_activo_tecnico`, pero solo se aplica en `tareas_correctivas`; el resto de CRUDs todavía registra en forma directa.
+
+### 3) Desalineado / legado detectado
+
+- `docs/setup.md` tenía comandos de ejecución/despliegue en rutas antiguas (`requirements.txt` y `app.py` en raíz).
+- Referencias documentales antiguas sin distinguir explícitamente entre modelo conceptual y campos persistidos en producción.
+- Algunos módulos auxiliares (`inventario`, `consumos`) usan nomenclaturas heredadas (`maquina_compatible`) que no están en el modelo conceptual principal.
+
+## Decisiones tomadas (cambios seguros aplicados)
+
+1. **No se tocaron colecciones persistidas ni campos en MongoDB.**
+2. Se actualizó documentación para dejar explícito el criterio de compatibilidad:
+   - Conceptual: `activo_padre` / `tipo_activo`.
+   - Operativo vigente: `pertenece_a` / `tipo`.
+3. Se corrigió guía de instalación para reflejar rutas reales del repositorio.
+4. Se actualizó README principal para alinear lenguaje operativo, alcance real y comandos válidos.
+
+## Pendientes de riesgo medio/alto (NO implementados)
+
+### Riesgo medio
+
+- Estandarizar labels/UI para reflejar explícitamente el mapeo conceptual ↔ operativo en todos los formularios.
+- Incorporar validaciones funcionales de criticidad (sin cambiar persistencia existente).
+
+### Riesgo alto
+
+- Renombrar campos persistidos (`tipo` → `tipo_activo`, `pertenece_a` → `activo_padre`).
+- Renombrar colecciones o introducir migraciones de datos.
+- Unificar todos los CRUDs bajo `CMMSRepository` sin plan de transición y pruebas integrales.
+
+## Criterio de transición recomendado
+
+- Mantener esquema actual por compatibilidad.
+- Aplicar dualidad documental y de UI (mostrar término conceptual + campo operativo real).
+- Cuando se planifique una migración, hacerlo con estrategia versionada, scripts de backfill, rollback y validación por ambiente.

--- a/docs/checklist_cruds_activos_tecnicos.md
+++ b/docs/checklist_cruds_activos_tecnicos.md
@@ -1,15 +1,18 @@
 # Comparación de CRUDs frente al Estándar de Activos Técnicos
 
-Este informe resume la alineación de los principales CRUDs del sistema con el estándar de campos definidos para `activos_tecnicos`.
+Este informe resume la alineación de los principales CRUDs del sistema con el estándar de campos definidos para `activos_tecnicos`, diferenciando **modelo conceptual** y **campos operativos actuales**.
 
 ## Estándar de campos para un activo técnico
 
 - `id_activo_tecnico`
 - `nombre`
 - `ubicacion`
-- `tipo`
+- `tipo_activo` *(conceptual en fuentes oficiales)*
+- `tipo` *(campo persistido vigente en código)*
 - `estado`
-- `pertenece_a` *(opcional)*
+- `activo_padre` *(conceptual en fuentes oficiales)*
+- `pertenece_a` *(campo persistido vigente, opcional)*
+- `nivel` *(opcional, jerarquía técnica)*
 - `usuario_registro`
 - `fecha_registro`
 
@@ -17,7 +20,7 @@ Este informe resume la alineación de los principales CRUDs del sistema con el e
 
 | Módulo | Campos clave utilizados | Cumple estándar |
 | ------ | ---------------------- | --------------- |
-| `crud_activos_tecnicos.py` | `id_activo_tecnico`, `nombre`, `ubicacion`, `tipo`, `estado`, `pertenece_a`, `usuario_registro`, `fecha_registro` | ✅ |
+| `crud_activos_tecnicos.py` | `id_activo_tecnico`, `nombre`, `ubicacion`, `tipo`, `estado`, `pertenece_a`, `nivel`, `usuario_registro`, `fecha_registro` | ✅ |
 | `crud_tareas_correctivas.py` | `id_activo_tecnico`, `id_tarea`, `descripcion_falla`, `fecha_evento`, `usuario_registro` | Parcial |
 | `crud_planes_preventivos.py` | `id_activo_tecnico`, `id_plan`, `descripcion`, `fecha_evento`, `usuario_registro` | Parcial |
 | `crud_tareas_tecnicas.py` | `id_activo_tecnico` *(opcional)*, `id_tarea_tecnica`, `descripcion`, `fecha_evento`, `usuario_registro` | Parcial |
@@ -29,7 +32,7 @@ La columna *Cumple estándar* indica si el módulo implementa todos los campos o
 
 ## Detalle de campos por CRUD
 
-- **crud_activos_tecnicos.py**: `id_activo_tecnico`, `nombre`, `ubicacion`, `tipo`, `estado`, `pertenece_a`, `responsable`, `usuario_registro`, `fecha_registro`.
+- **crud_activos_tecnicos.py**: `id_activo_tecnico`, `nombre`, `ubicacion`, `tipo`, `estado`, `pertenece_a`, `nivel`, `responsable`, `usuario_registro`, `fecha_registro`.
 - **crud_tareas_correctivas.py**: `id_tarea`, `id_activo_tecnico`, `fecha_evento`, `descripcion_falla`, `modo_falla`, `responsable`, `proveedor_externo`, `estado`, `usuario_registro`, `observaciones`, `fecha_registro`.
 - **crud_planes_preventivos.py**: `id_plan`, `id_activo_tecnico`, `frecuencia`, `unidad_frecuencia`, `proxima_fecha`, `ultima_fecha`, `responsable`, `proveedor_externo`, `estado`, `adjunto_plan`, `usuario_registro`, `observaciones`, `fecha_registro`.
 - **crud_tareas_tecnicas.py**: `id_tarea_tecnica`, `id_activo_tecnico` *(opcional)*, `fecha_evento`, `descripcion`, `tipo_tecnica`, `responsable`, `proveedor_externo`, `estado`, `usuario_registro`, `observaciones`, `fecha_registro`.
@@ -42,5 +45,5 @@ La columna *Cumple estándar* indica si el módulo implementa todos los campos o
 
 - [x] Cada CRUD registra `usuario_registro` y fecha de creación para trazabilidad.
 - [x] Los eventos quedan centralizados en la colección `historial` vía `generador_historial.py`.
+- [x] Se documenta compatibilidad entre campos conceptuales (`tipo_activo`, `activo_padre`) y campos operativos vigentes (`tipo`, `pertenece_a`).
 - [x] Documentar en futuros desarrollos los campos específicos de cada CRUD para facilitar auditorías.
-

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,6 +2,8 @@
 
 1. Clona el repositorio.
 2. Crea un entorno virtual y activa.
-3. Instala las dependencias con `pip install -r requirements.txt`.
-4. Configura las variables en `.env`.
-5. Ejecuta `streamlit run app.py`.
+3. Instala las dependencias con `pip install -r cmms_fabrica/requirements.txt`.
+4. Configura las variables en `.env`:
+   - `MONGO_URI`
+   - `DB_NAME` (opcional, default: `cmms`)
+5. Ejecuta `streamlit run cmms_fabrica/app.py`.


### PR DESCRIPTION
### Motivation
- Auditar la coherencia entre las fuentes oficiales en `/docs`, la implementación real y la documentación visible para evitar divergencias operativas.
- Alinear la documentación pública con el estado actual del código sin tocar la persistencia ni aplicar migraciones silenciosas.
- Dejar registrado un plan y pendientes de riesgo medio/alto para futuras migraciones o refactors de mayor impacto.

### Description
- Añadido `docs/alineacion_repo_fuentes.md` con el resultado de la auditoría, decisiones tomadas y pendientes de riesgo medio/alto. 
- Actualizado `README.md` para reflejar el modelo conceptual efectivo (jerarquía/nivel) y la compatibilidad operativa (`tipo` ↔ `tipo_activo`, `pertenece_a` ↔ `activo_padre`) y comandos reales de ejecución (`streamlit run cmms_fabrica/app.py`).
- Corregido `docs/setup.md` para usar `cmms_fabrica/requirements.txt` y `streamlit run cmms_fabrica/app.py`, y explicitar variables de entorno (`MONGO_URI`, `DB_NAME`).
- Ajustado `docs/checklist_cruds_activos_tecnicos.md` para diferenciar campos conceptuales vs. campos persistidos vigentes y documentar la compatibilidad.
- Cambiado texto/ayuda en UI de `cmms_fabrica/crud/crud_activos_tecnicos.py` para aclarar que el campo operativo se llama `tipo` y que la relación padre se guarda en `pertenece_a`, sin renombrar campos ni modificar la persistencia.

### Testing
- Ejecutadas comprobaciones de repositorio y detección de colecciones con `rg --files` y un script Python de inspección de `cmms_fabrica` (búsqueda de referencias a colecciones), y ambas consultas completaron correctamente.
- Verificado estado de cambios con `git status --short` y creado commit con `git commit -m "docs: auditar y alinear repo con fuentes oficiales"`, commit exitoso.
- No se ejecutó `pytest` porque los cambios se limitaron a documentación y labels/UI (regla: evitar pruebas cuando se editan solo textos); por esa razón no se modificó lógica ni estructura de datos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f6392364832baafd7ed0c2735ffb)