### PR TITLE
Add criticidad tracking across observations, tasks, historial, reports and KPI deduplication

### DIFF
--- a/cmms_fabrica/crud/crud_observaciones.py
+++ b/cmms_fabrica/crud/crud_observaciones.py
@@ -13,10 +13,17 @@ from cmms_fabrica.crud.generador_historial import registrar_evento_historial
 
 tipos_observacion = ["Advertencia", "Hallazgo", "Ruido", "Otro"]
 estados_posibles = ["Pendiente", "Revisado"]
+criticidades = ["Sin clasificar", "Baja", "Media", "Alta", "Crítica"]
 
 
 def generar_id_observacion():
     return f"OBS_{int(datetime.now().timestamp())}"
+
+
+def _normalizar_criticidad(valor):
+    if not valor or valor == "Sin clasificar":
+        return None
+    return valor
 
 
 def form_observacion(activos, defaults=None):
@@ -92,6 +99,13 @@ def form_observacion(activos, defaults=None):
             "Notas adicionales",
             value=defaults.get("observaciones") if defaults else ""
         )
+        criticidad = st.selectbox(
+            "Criticidad (opcional)",
+            criticidades,
+            index=criticidades.index(defaults.get("criticidad"))
+            if defaults and defaults.get("criticidad") in criticidades
+            else 0
+        )
 
         submit = st.form_submit_button("Guardar Observación")
 
@@ -110,6 +124,7 @@ def form_observacion(activos, defaults=None):
             "estado": estado,
             "usuario_registro": usuario,
             "observaciones": observaciones,
+            "criticidad": _normalizar_criticidad(criticidad),
             "fecha_registro": datetime.now()
         }
 
@@ -145,6 +160,7 @@ def app():
                 usuario=data["usuario_registro"],
                 id_origen=data["id_observacion"],
                 observaciones=data.get("observaciones"),
+                criticidad=data.get("criticidad"),
             )
             st.success("✅ Observación registrada correctamente.")
 
@@ -189,7 +205,8 @@ def app():
                     id_info = f"ID: {o.get('id_observacion', '')} | Activo: {o.get('id_activo_tecnico', '')}"
                     st.code(id_info, language="yaml")
                     st.markdown(
-                        f"- **{o.get('descripcion', '')[:80]}** ({o.get('fecha_evento', '')})"
+                        f"- **{o.get('descripcion', '')[:80]}** ({o.get('fecha_evento', '')}) · "
+                        f"Criticidad: {o.get('criticidad') or 'Sin clasificar'}"
                     )
 
     elif choice == "Editar Observación":
@@ -217,6 +234,7 @@ def app():
                 usuario=nuevos_datos["usuario_registro"],
                 id_origen=nuevos_datos["id_observacion"],
                 observaciones=nuevos_datos.get("observaciones"),
+                criticidad=nuevos_datos.get("criticidad"),
             )
             st.success("✅ Observación actualizada correctamente.")
 
@@ -244,6 +262,7 @@ def app():
                 usuario=datos.get("usuario_registro", "desconocido"),
                 id_origen=datos.get("id_observacion"),
                 observaciones=datos.get("observaciones"),
+                criticidad=datos.get("criticidad"),
             )
             st.success("🗑️ Observación eliminada correctamente.")
 

--- a/cmms_fabrica/crud/crud_tareas_correctivas.py
+++ b/cmms_fabrica/crud/crud_tareas_correctivas.py
@@ -54,6 +54,17 @@ def _to_datetime(value: Optional[object]) -> datetime:
     return datetime.utcnow()
 
 
+def _normalizar_criticidad(valor: Optional[str]) -> Optional[str]:
+    """Normaliza criticidad de UI a persistencia.
+
+    - ``Sin clasificar`` se guarda como ``None`` para no contaminar datos.
+    - valores vacíos también se guardan como ``None``.
+    """
+    if not valor or valor == "Sin clasificar":
+        return None
+    return valor
+
+
 def shared_section(title: str, subtitle: Optional[str] = None):
     st.markdown(f"### {title}")
     if subtitle:
@@ -63,6 +74,7 @@ def shared_section(title: str, subtitle: Optional[str] = None):
 
 def form_tarea(database, defaults: Optional[Dict[str, Any]] = None):
     defaults = defaults or {}
+    criticidades = ["Sin clasificar", "Baja", "Media", "Alta", "Crítica"]
     with st.form("form_tarea_correctiva"):
         ids_activos: List[str] = select_activo_tecnico(database)
         id_default = defaults.get("id_activo_tecnico")
@@ -154,6 +166,13 @@ def form_tarea(database, defaults: Optional[Dict[str, Any]] = None):
             "Observaciones adicionales",
             value=defaults.get("observaciones", ""),
         ).strip()
+        criticidad = st.selectbox(
+            "Criticidad (opcional)",
+            criticidades,
+            index=criticidades.index(defaults.get("criticidad"))
+            if defaults.get("criticidad") in criticidades
+            else 0,
+        )
         submit = st.form_submit_button("Guardar Tarea")
 
     if submit:
@@ -182,6 +201,7 @@ def form_tarea(database, defaults: Optional[Dict[str, Any]] = None):
             "estado": estado,
             "usuario_registro": usuario,
             "observaciones": observaciones,
+            "criticidad": _normalizar_criticidad(criticidad),
             "fecha_registro": _to_datetime(defaults.get("fecha_registro")),
             "incompleto": False,
         }
@@ -219,6 +239,7 @@ def app():
                             id_origen=data.get("id_tarea"),
                             proveedor_externo=data.get("proveedor_externo") or None,
                             observaciones=data.get("observaciones") or None,
+                            criticidad=data.get("criticidad") or None,
                         ),
                     )
                 except ValueError as exc:
@@ -279,6 +300,7 @@ def app():
                         activo = t.get("id_activo_tecnico", "—")
                         id_tarea = t.get("id_tarea", "—")
                         responsable = t.get("responsable", "—")
+                        criticidad = t.get("criticidad") or "Sin clasificar"
 
                         st.markdown(
                             f"""
@@ -300,6 +322,9 @@ def app():
   </p>
   <p style="margin:0.15rem 0 0; font-size:0.72rem; color:#9ca3af;">
     <strong>Responsable:</strong> {responsable} · <strong>Fecha:</strong> {fecha_str}
+  </p>
+  <p style="margin:0.15rem 0 0; font-size:0.72rem; color:#fbbf24;">
+    <strong>Criticidad:</strong> {criticidad}
   </p>
   <p style="margin:0.4rem 0 0; font-size:0.7rem;">
     <span style="
@@ -329,6 +354,7 @@ def app():
                                     "Descripción": t.get("descripcion_falla"),
                                     "Fecha evento": t.get("fecha_evento"),
                                     "Responsable": t.get("responsable"),
+                                    "Criticidad": t.get("criticidad") or "Sin clasificar",
                                 }
                                 for t in filtradas
                             ]
@@ -367,6 +393,7 @@ def app():
                                     id_origen=nuevos_datos.get("id_tarea"),
                                     proveedor_externo=nuevos_datos.get("proveedor_externo") or None,
                                     observaciones=nuevos_datos.get("observaciones") or None,
+                                    criticidad=nuevos_datos.get("criticidad") or None,
                                 ),
                             )
                         except ValueError as exc:
@@ -409,6 +436,7 @@ def app():
                                     id_origen=datos.get("id_tarea"),
                                     proveedor_externo=datos.get("proveedor_externo") or None,
                                     observaciones=datos.get("observaciones") or None,
+                                    criticidad=datos.get("criticidad") or None,
                                 ),
                                 document=datos,
                             )

--- a/cmms_fabrica/crud/dashboard_kpi_historial.py
+++ b/cmms_fabrica/crud/dashboard_kpi_historial.py
@@ -39,6 +39,28 @@ def categorizar_tipo_evento(tipo_evento: str) -> str:
         return "tecnica"
     return "otro"
 
+
+def filtrar_ultimo_evento_por_origen(df: pd.DataFrame) -> pd.DataFrame:
+    """Evita duplicación de KPIs manteniendo el último evento por origen.
+
+    Se agrupa por combinación de:
+    - id_activo_tecnico
+    - tipo_evento_categoria
+    - id_origen (cuando existe)
+    """
+    columnas_requeridas = {"id_activo_tecnico", "tipo_evento_categoria", "fecha_evento"}
+    if not columnas_requeridas.issubset(df.columns):
+        return df
+
+    df_base = df.copy()
+    if "id_origen" not in df_base.columns:
+        df_base["id_origen"] = ""
+
+    df_base["id_origen"] = df_base["id_origen"].fillna("").astype(str)
+    df_ordenado = df_base.sort_values("fecha_evento", ascending=False)
+    idx = df_ordenado.groupby(["id_activo_tecnico", "tipo_evento_categoria", "id_origen"])["fecha_evento"].idxmax()
+    return df_ordenado.loc[idx].reset_index(drop=True)
+
 def app():
     if db is None:
         st.error("MongoDB no disponible")
@@ -104,6 +126,8 @@ def app():
 
     df["mes"] = df["fecha_evento"].dt.to_period("M")
     df["usuario_registro"] = df.get("usuario_registro", df.get("usuario", "desconocido"))
+    df["criticidad"] = df.get("criticidad", "").replace("", "Sin clasificar").fillna("Sin clasificar")
+    df = filtrar_ultimo_evento_por_origen(df)
 
     # KPIs Principales
     st.header("📌 Indicadores Clave")
@@ -111,6 +135,12 @@ def app():
     col1.metric("Eventos Registrados", len(df))
     col2.metric("Activos Afectados", df["id_activo_tecnico"].nunique())
     col3.metric("Usuarios Participantes", df["usuario_registro"].nunique())
+
+    st.subheader("🚦 Distribución de criticidad")
+    criticidad_counts = df["criticidad"].value_counts().reindex(
+        ["Crítica", "Alta", "Media", "Baja", "Sin clasificar"], fill_value=0
+    )
+    st.bar_chart(criticidad_counts)
 
     # Gráfico: Eventos por tipo
     st.subheader("📈 Eventos por Tipo")
@@ -156,7 +186,7 @@ def app():
     st.subheader("📋 Detalle de Eventos Técnicos")
     st.dataframe(df[[
         "fecha_evento", "tipo_evento", "id_activo_tecnico",
-        "descripcion", "usuario_registro"
+        "criticidad", "descripcion", "usuario_registro"
     ]].sort_values("fecha_evento", ascending=False))
 
 if __name__ == "__main__":

--- a/cmms_fabrica/crud/generador_historial.py
+++ b/cmms_fabrica/crud/generador_historial.py
@@ -21,6 +21,7 @@ def registrar_evento_historial(
     id_origen: str | None = None,
     proveedor_externo: str | None = None,
     observaciones: str | None = None,
+    criticidad: str | None = None,
 ) -> str:
     """Inserta un evento consolidado en la colección ``historial``.
 
@@ -47,7 +48,8 @@ def registrar_evento_historial(
         "descripcion": descripcion,
         "usuario_registro": usuario,
         "proveedor_externo": proveedor_externo,
-        "observaciones": observaciones or ""
+        "observaciones": observaciones or "",
+        "criticidad": criticidad or "",
     }
 
     historial.insert_one(evento)

--- a/cmms_fabrica/modulos/app_reportes.py
+++ b/cmms_fabrica/modulos/app_reportes.py
@@ -58,6 +58,7 @@ class PDF(FPDF):
             origen = row.get('id_origen') or "HUÉRFANO"
             self.multi_cell(0, 6, safe_text(f"ID de origen: {origen}"), 0)
             self.multi_cell(0, 6, safe_text(f"Usuario: {row.get('usuario_registro', '-')}"), 0)
+            self.multi_cell(0, 6, safe_text(f"Criticidad: {row.get('criticidad', '-')}"), 0)
             self.set_font("Arial", "B", 10)
             self.multi_cell(0, 6, safe_text("Descripción:"), 0)
             self.set_font("Arial", "", 10)
@@ -172,7 +173,7 @@ def app():
         st.warning("No se encontraron eventos técnicos para las categorías seleccionadas.")
         return
 
-    for campo in ["usuario_registro", "descripcion", "observaciones", "id_origen"]:
+    for campo in ["usuario_registro", "descripcion", "observaciones", "id_origen", "criticidad"]:
         if campo not in df.columns:
             df[campo] = "" if campo == "id_origen" else "-"
     df["usuario_registro"] = df["usuario_registro"].fillna("desconocido")
@@ -180,7 +181,16 @@ def app():
 
     df_filtrado = filtrar_ultimo_por_tarea_y_activo(df)
 
-    columnas = ["fecha_evento", "tipo_evento", "id_activo_tecnico", "id_origen", "descripcion", "usuario_registro", "observaciones"]
+    columnas = [
+        "fecha_evento",
+        "tipo_evento",
+        "id_activo_tecnico",
+        "id_origen",
+        "criticidad",
+        "descripcion",
+        "usuario_registro",
+        "observaciones",
+    ]
     for col in columnas:
         if col not in df_filtrado.columns:
             df_filtrado[col] = "HUÉRFANO" if col == "id_origen" else "-"

--- a/cmms_fabrica/modulos/repository.py
+++ b/cmms_fabrica/modulos/repository.py
@@ -38,6 +38,7 @@ class HistorialEvent:
     id_origen: Optional[str] = None
     proveedor_externo: Optional[str] = None
     observaciones: Optional[str] = None
+    criticidad: Optional[str] = None
 
 
 class CMMSRepository:
@@ -89,6 +90,7 @@ class CMMSRepository:
             id_origen=id_origen,
             proveedor_externo=event.proveedor_externo or payload.get("proveedor_externo"),
             observaciones=event.observaciones or payload.get("observaciones"),
+            criticidad=event.criticidad or payload.get("criticidad"),
         )
         return str(result.inserted_id)
 
@@ -123,6 +125,7 @@ class CMMSRepository:
             id_origen=id_origen,
             proveedor_externo=event.proveedor_externo or payload.get("proveedor_externo"),
             observaciones=event.observaciones or payload.get("observaciones"),
+            criticidad=event.criticidad or payload.get("criticidad"),
         )
         return result.modified_count
 
@@ -159,6 +162,7 @@ class CMMSRepository:
                 id_origen=id_origen,
                 proveedor_externo=event.proveedor_externo or registro.get("proveedor_externo"),
                 observaciones=event.observaciones or registro.get("observaciones"),
+                criticidad=event.criticidad or registro.get("criticidad"),
             )
 
         return result.deleted_count

--- a/tests/test_crud_observaciones.py
+++ b/tests/test_crud_observaciones.py
@@ -53,6 +53,7 @@ def test_registrar_observacion_inserta_observacion_y_historial():
         "estado": "Pendiente",
         "usuario_registro": "tecnico_cmms",
         "observaciones": "Verificar vibración en próxima ronda",
+        "criticidad": "Media",
         "fecha_registro": 0,
     }
 
@@ -72,3 +73,12 @@ def test_registrar_observacion_inserta_observacion_y_historial():
     assert evento is not None
     assert evento["id_origen"] == "OBS-100"
     assert evento["usuario_registro"] == "tecnico_cmms"
+    assert evento["criticidad"] == "Media"
+    observacion = db_mock.observaciones.find_one({"id_observacion": "OBS-100"})
+    assert observacion["criticidad"] == "Media"
+
+
+def test_normalizar_criticidad_observacion_guarda_none_para_sin_clasificar():
+    assert crud_observaciones._normalizar_criticidad("Sin clasificar") is None
+    assert crud_observaciones._normalizar_criticidad(None) is None
+    assert crud_observaciones._normalizar_criticidad("Alta") == "Alta"

--- a/tests/test_crud_tareas_correctivas.py
+++ b/tests/test_crud_tareas_correctivas.py
@@ -25,6 +25,7 @@ def test_crear_tarea_correctiva_registra_historial():
             "estado": "Abierta",
             "usuario_registro": "tech",
             "observaciones": "",
+            "criticidad": "Alta",
             "fecha_registro": 0,
             "incompleto": False,
         }
@@ -44,6 +45,7 @@ def test_crear_tarea_correctiva_registra_historial():
                 id_origen=data["id_tarea"],
                 proveedor_externo=data.get("proveedor_externo") or None,
                 observaciones=data.get("observaciones") or None,
+                criticidad=data.get("criticidad") or None,
             ),
         )
 
@@ -54,3 +56,12 @@ def test_crear_tarea_correctiva_registra_historial():
         assert evento["id_activo_tecnico"] == "A1"
         assert evento["usuario_registro"] == "tech"
         assert evento["id_origen"] == "TC1"
+        assert evento["criticidad"] == "Alta"
+        tarea = db_mock.tareas_correctivas.find_one({"id_tarea": "TC1"})
+        assert tarea["criticidad"] == "Alta"
+
+
+def test_normalizar_criticidad_tarea_guarda_none_para_sin_clasificar():
+    assert crud_tareas_correctivas._normalizar_criticidad("Sin clasificar") is None
+    assert crud_tareas_correctivas._normalizar_criticidad("") is None
+    assert crud_tareas_correctivas._normalizar_criticidad("Media") == "Media"

--- a/tests/test_reportes.py
+++ b/tests/test_reportes.py
@@ -5,6 +5,7 @@ from cmms_fabrica.modulos.app_reportes import (
     generar_excel,
     filtrar_ultimo_por_activo,
 )
+from cmms_fabrica.crud.dashboard_kpi_historial import filtrar_ultimo_evento_por_origen
 
 
 def test_generar_reportes_con_observaciones(tmp_path):
@@ -13,6 +14,7 @@ def test_generar_reportes_con_observaciones(tmp_path):
         "tipo_evento": ["test"],
         "id_activo_tecnico": ["A1"],
         "id_origen": ["EV-1"],
+        "criticidad": ["Alta"],
         "descripcion": ["ok"],
         "observaciones": ["-"],
         "usuario_registro": ["user"],
@@ -29,6 +31,7 @@ def test_generar_reportes_con_observaciones(tmp_path):
         "tipo_evento",
         "id_activo_tecnico",
         "id_origen",
+        "criticidad",
         "descripcion",
         "observaciones",
         "usuario_registro",
@@ -97,3 +100,22 @@ def test_filtrado_por_categoria_evento_en_dataframe():
 
     assert len(filtrado) == 2
     assert set(filtrado["categoria_evento"]) == {"observacion", "correctiva"}
+
+
+def test_kpi_filtra_ultimo_evento_por_origen_para_evitar_duplicados():
+    df = pd.DataFrame(
+        {
+            "id_activo_tecnico": ["A1", "A1", "A1"],
+            "id_origen": ["TC-1", "TC-1", "OBS-1"],
+            "tipo_evento_categoria": ["correctiva", "correctiva", "observacion"],
+            "fecha_evento": [
+                pd.Timestamp("2024-01-01"),
+                pd.Timestamp("2024-01-05"),
+                pd.Timestamp("2024-01-03"),
+            ],
+        }
+    )
+    filtrado = filtrar_ultimo_evento_por_origen(df)
+    assert len(filtrado) == 2
+    correctiva = filtrado[filtrado["id_origen"] == "TC-1"].iloc[0]
+    assert correctiva["fecha_evento"] == pd.Timestamp("2024-01-05")


### PR DESCRIPTION
### Motivation
- Registrar y propagar una criticidad opcional para Observaciones y Tareas Correctivas para mejorar priorización y reportes en el CMMS. 
- Evitar la duplicación en los KPIs cuando un mismo origen genera múltiples eventos, tomando el último evento por origen.

### Description
- Añade la selección de `criticidad` en las UIs `form_observacion` y `form_tarea` y aplica la normalización con `_normalizar_criticidad` para guardar `None` cuando corresponde. 
- Extiende `registrar_evento_historial` para aceptar y persistir `criticidad`, y actualiza `HistorialEvent` y las llamadas en `CMMSRepository` para transmitir la criticidad en `insert_with_log`, `update_with_log` y `delete_with_log`. 
- Integra `criticidad` en reporting y dashboards: incluye campo en `app_reportes.PDF` y en la tabla/listados, agrega visualización de distribución en `dashboard_kpi_historial` y normaliza/filtra la columna; además implementa `filtrar_ultimo_evento_por_origen` para evitar duplicados en KPIs. 
- Actualiza tests y fixtures para cubrir persistencia y normalización de `criticidad` en `tests/test_crud_observaciones.py`, `tests/test_crud_tareas_correctivas.py` y `tests/test_reportes.py`.

### Testing
- Ejecuté la suite de pruebas automatizadas con `pytest -q` incluyendo the modified tests `tests/test_crud_observaciones.py`, `tests/test_crud_tareas_correctivas.py` y `tests/test_reportes.py`, y todas las pruebas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2f92fd0a4832baa448c6b34562e87)